### PR TITLE
Allow flexible tags for the release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-    - "v[0-9]+.[0-9]+.[0-9]+"
+    - "v[0-9]+.[0-9]+.[0-9]+.*"
 
 jobs:
   release:


### PR DESCRIPTION
We'd like to use like `v1.1.0-pfnet.1` as the tag name to make it clear the release comes from the forked repository.