### PR TITLE
Dockerfile: Maintains compatibility with original version

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,5 +1,5 @@
 FROM debian:bullseye-slim
 WORKDIR /
-COPY manager /usr/local/bin/manager
-COPY apiextension /usr/local/bin/apiextension
-ENTRYPOINT ["/usr/local/bin/manager"]
+COPY manager /manager
+COPY apiextension /apiextension
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
We'll avoid applying unnecessary patches to the manifest.