### PR TITLE
Add the tests for Scoped HRQ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,6 @@ buildx-setup:
 docker-push-multi: buildx-setup generate fmt vet staticcheck
 	@echo "Warning: this does not run tests. Run 'make test' to ensure tests are passing."
 	docker buildx build \
-	--push \
 	--platform linux/arm64,linux/amd64,linux/arm/v7  --tag ${HNC_IMG} .
 
 ###################### KIND ACTIONS #########################
@@ -356,6 +355,13 @@ test-e2e-batch: warn-hnc-repair
 		go clean -testcache ; \
 		go test -v -timeout 0 ./test/e2e/... ; \
 	done
+
+PHONY: test-pfnet-e2e-parallel
+test-pfnet-e2e-parallel:
+	kind get kubeconfig --name kind > /tmp/kind-hnc-config
+	export KUBECONFIG=/tmp/kind-hnc-config && kubectl -n hnc-system patch deployment hnc-controller-manager -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","resources":{"limits":{"cpu":null}}}]}}}}'
+	export KUBECONFIG=/tmp/kind-hnc-config && kubectl -n hnc-system wait --for=condition=available deployment/hnc-controller-manager --timeout=5m
+	export KUBECONFIG=/tmp/kind-hnc-config && ginkgo run -p --label-filter pfnet ./test/e2e/...
 
 # This will *only* run a small number of tests (specifically, the quickstarts). You can run this when you're fairly confident that
 # everything will work, but be sure to watch for the postsubmits and periodic tests to ensure they pass too.

--- a/test/e2e/delete_crd_test.go
+++ b/test/e2e/delete_crd_test.go
@@ -7,7 +7,7 @@ import (
 	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
 )
 
-var _ = Describe("When deleting CRDs", func() {
+var _ = Describe("When deleting CRDs", Serial, func() {
 
 	const (
 		nsParent = "delete-crd-parent"

--- a/test/e2e/hrq_test.go
+++ b/test/e2e/hrq_test.go
@@ -29,7 +29,7 @@ const (
 )
 
 // HRQ tests are pending (disabled) until we turn them on in all the default manifests
-var _ = PDescribe("Hierarchical Resource Quota", func() {
+var _ = PDescribe("Hierarchical Resource Quota", Serial, func() {
 	BeforeEach(func() {
 		rand.Seed(time.Now().UnixNano())
 		CleanupTestNamespaces()

--- a/test/e2e/issues_test.go
+++ b/test/e2e/issues_test.go
@@ -7,7 +7,7 @@ import (
 	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
 )
 
-var _ = Describe("Issues", func() {
+var _ = Describe("Issues", Serial, func() {
 
 	const (
 		nsParent   = "parent"

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -8,7 +8,7 @@ import (
 	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
 )
 
-var _ = Describe("Namespace", func() {
+var _ = Describe("Namespace", Serial, func() {
 	const (
 		prefix              = namspacePrefix + "namespace-"
 		nsA                 = prefix + "a"

--- a/test/e2e/pfn_hrq_test.go
+++ b/test/e2e/pfn_hrq_test.go
@@ -1,0 +1,235 @@
+package e2e
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/yaml"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
+)
+
+var _ = Describe("Scoped Hierarchical Resource Quota", Label("pfnet"), func() {
+	var (
+		parentNs, childNs, priorityName     string
+		cleanupNs, cleanupPriority     func()
+		scopeSelector corev1.ScopeSelector
+		normalHRQ api.HierarchicalResourceQuota
+	)
+
+	BeforeEach(func() {
+		parentNs, childNs, cleanupNs = setUpParentAndChild()
+		scopeSelector, priorityName, cleanupPriority = genPriorityScopeSelector()
+
+		// For checking not-scoped HRQ with scoped HRQ.
+		normalHRQ = setScopedHRQ("normal-hrq", parentNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("100")}, nil)
+	})
+
+	AfterEach(func() {
+		var podCount int
+		for _, ns := range []string{parentNs, childNs} {
+			out, err := RunCommand("kubectl get --no-headers pods -n " + ns)
+			Expect(err).NotTo(HaveOccurred())
+			if strings.Contains(out, "No resources found") {
+				continue
+			}
+
+			pods := strings.Count(out, "\n")
+			Expect(err).NotTo(HaveOccurred())
+			podCount += pods
+		}
+
+		FieldShouldContainWithTimeout("hrq", parentNs, normalHRQ.Name, ".status.used", "pods:"+strconv.Itoa(podCount), 300)
+
+		// For debugging after failed tests
+		if !CurrentSpecReport().Failed() {
+			cleanupPriority()
+			cleanupNs()
+		}
+	})
+
+	It("should create RQs with correct limits in the descendants (including itself) for Scoped HRQs", func() {
+		hrqA := setScopedHRQ("a-hrq", parentNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("3")}, &scopeSelector)
+		hrqB := setScopedHRQ("b-hrq", childNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("2")}, &scopeSelector)
+
+		rqAName := api.ResourceQuotaSingletonName + "-" + hrqA.Name
+		rqBName := api.ResourceQuotaSingletonName + "-" + hrqB.Name
+
+		FieldShouldContain("resourcequota", parentNs, rqAName, ".spec.hard", "pods:3")
+		FieldShouldContain("resourcequota", childNs, rqBName, ".spec.hard", "pods:2")
+
+		expect := selectorStr(priorityName)
+		FieldShouldContain("resourcequota", parentNs, rqAName, ".spec.scopeSelector", expect)
+		FieldShouldContain("resourcequota", childNs, rqBName, ".spec.scopeSelector", expect)
+	})
+
+	It("should remove obsolete (empty) RQ if there's no longer a Scoped HRQ in the ancestor", func() {
+		hrq := setScopedHRQ("a-hrq", parentNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("3")}, &scopeSelector)
+		rqName := api.ResourceQuotaSingletonName + "-" + hrq.Name
+
+		MustRun("kubectl delete hrq -n", parentNs, hrq.Name)
+
+		RunShouldNotContain(rqName, propagationTime, "kubectl get resourcequota -n" , parentNs)
+		RunShouldNotContain(rqName, propagationTime, "kubectl get resourcequota -n" , childNs)
+	})
+
+	It("should update the .status.used field of the HRQ when pods are created", func() {
+		hrq := setScopedHRQ("status-updated", parentNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("2")}, &scopeSelector)
+
+		for i := 0; i < 2; i++ {
+			_, err := mustCreatePodWithPrioirty(fmt.Sprint(i), childNs, priorityName)
+			Expect(err).NotTo(HaveOccurred())
+			FieldShouldContain("hrq", parentNs, hrq.Name, ".status.used", "pods:"+fmt.Sprint(i+1))
+		}
+
+		_, err := mustCreatePod("normal", childNs)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should reject creating a pod if the HRQ is exceeded", func() {
+		hrq := setScopedHRQ("ok-ng", parentNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")}, &scopeSelector)
+
+		_, err := mustCreatePodWithPrioirty("ok", childNs, priorityName)
+		Expect(err).NotTo(HaveOccurred())
+		FieldShouldContain("hrq", parentNs, hrq.Name, ".status.used", "pods:1")
+
+		_, err = mustCreatePodWithPrioirty("ng", childNs, priorityName)
+		Expect(err).ShouldNot(Succeed())
+
+		_, err = mustCreatePod("normal-pod", childNs)
+		Expect(err).NotTo(HaveOccurred())
+
+		FieldShouldContain("hrq", parentNs, hrq.Name, ".status.used", "pods:1")
+	})
+})
+
+func mustCreatePod(prefix, nsnm string) (corev1.Pod, error) {
+	return mustCreatePodWithPrioirty(prefix, nsnm, "")
+}
+
+func mustCreatePodWithPrioirty(prefix, nsnm, priority string) (corev1.Pod, error) {
+	name := prefix + "-" +  uuid.New().String()
+	spec := corev1.PodSpec{
+		PriorityClassName: priority,
+		Containers: []corev1.Container{
+			{
+				Name:  "test",
+				Image: "nginx",
+			},
+		},
+	}
+	if priority != "" {
+		spec.PriorityClassName = priority
+	}
+
+	pod := corev1.Pod {
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: nsnm,
+		},
+		Spec: spec,
+	}
+
+	manifest, err := yaml.Marshal(pod)
+	Expect(err).NotTo(HaveOccurred())
+
+	fn := writeTempFile(string(manifest))
+	GinkgoT().Log("Wrote " + fn + ":\n" + string(manifest))
+	defer removeFile(fn)
+
+	return pod, TryRun("kubectl apply -f " + fn)
+}
+
+func setScopedHRQ(nm, nsnm string, resourceList corev1.ResourceList, scopeSelector *corev1.ScopeSelector) api.HierarchicalResourceQuota {
+	hrq := api.HierarchicalResourceQuota{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HierarchicalResourceQuota",
+			APIVersion: "hnc.x-k8s.io/v1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nm,
+			Namespace: nsnm,
+		},
+		Spec: api.HierarchicalResourceQuotaSpec{
+			Hard: resourceList,
+			ScopeSelector: scopeSelector,
+		},
+	}
+	manifest, err := yaml.Marshal(hrq)
+	Expect(err).NotTo(HaveOccurred())
+
+	MustApplyYAML(string(manifest))
+	RunShouldContain(nm, propagationTime, "kubectl get hrq -n", nsnm, nm)
+
+	return hrq
+}
+
+func setUpParentAndChild() (string, string, func()) {
+	parentNs := createNS("hrq-test-parent-")
+	childNs := createSubNS(parentNs)
+	cleanup := func() {
+		MustRunWithTimeout(cleanupTimeout, "kubectl annotate ns", parentNs, "hnc.x-k8s.io/subnamespace-of-")
+		MustRunWithTimeout(cleanupTimeout, "kubectl annotate ns", childNs, "hnc.x-k8s.io/subnamespace-of-")
+		var wg sync.WaitGroup
+		for _, ns := range []string{parentNs, childNs} {
+			wg.Add(1)
+			go func(ns string) {
+				MustRun("kubectl delete ns", ns)
+				wg.Done()
+			}(ns)
+		}
+		wg.Wait()
+	}
+
+	RunShouldContain(childNs, propagationTime, "kubectl get ns")
+	return parentNs, childNs, cleanup
+}
+
+func createNS(prefix string) string {
+	nsName := prefix + uuid.New().String()
+	MustRun("kubectl create ns", nsName)
+	return nsName
+}
+
+func createSubNS(parent string) string {
+	nsName := "hrq-test-child-" + uuid.New().String()
+	MustRun("kubectl hns create", nsName, "-n", parent)
+	return nsName
+}
+
+func genPriorityScopeSelector() (corev1.ScopeSelector, string, func()) {
+	priority := uuid.New().String()
+	err := TryRun("kubectl create priorityclass", priority, "--value=100")
+	Expect(err).NotTo(HaveOccurred())
+	cleanup := func() {
+		err := TryRun("kubectl delete priorityclass", priority)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	return corev1.ScopeSelector{
+		MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
+			{
+				Operator: corev1.ScopeSelectorOpIn,
+				ScopeName: "PriorityClass",
+				Values:   []string{priority},
+			},
+		},
+	}, priority, cleanup
+}
+
+func selectorStr(priorityName string) string {
+	return "map[matchExpressions:[map[operator:In scopeName:PriorityClass values:[" + priorityName + "]]]]"
+}

--- a/test/e2e/quickstart_test.go
+++ b/test/e2e/quickstart_test.go
@@ -8,7 +8,7 @@ import (
 	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
 )
 
-var _ = Describe("Quickstart", func() {
+var _ = Describe("Quickstart", Serial, func() {
 	// Tests for the HNC user guide quickstarts
 	const (
 		nsOrg      = "acme-org"


### PR DESCRIPTION
This PR includes two points

* Add the tests for scoped HRQs
* Some tests are marked `Serial` in order to run the tests in parallel

It was necessary to make major changes to the existing tests in order to run the tests in parallel. For this reason, I separated the files and gave them the label `pfnet`. This avoids conflicts with upstream as much as possible.