### PR TITLE
Handles cases where a namespace that is not a sub-namespace is mixed in

### DIFF
--- a/internal/forest/namespacehrq.go
+++ b/internal/forest/namespacehrq.go
@@ -188,7 +188,8 @@ func (n *Namespace) UseResources(rqName string, newUsage v1.ResourceList) error 
 
 		nsQuota, ok := ns.quotas[rqName]
 		if !ok {
-			return fmt.Errorf("no quota found for %q", rqName)
+			// This is a parent or above namespace.
+			continue
 		}
 
 		// Get the new subtree usage and remove no longer limited usages.

--- a/test/e2e/pfn_hrq_test.go
+++ b/test/e2e/pfn_hrq_test.go
@@ -178,13 +178,16 @@ func setScopedHRQ(nm, nsnm string, resourceList corev1.ResourceList, scopeSelect
 }
 
 func setUpParentAndChild() (string, string, func()) {
-	parentNs := createNS("hrq-test-parent-")
-	childNs := createSubNS(parentNs)
+	// There was the case where bug has occurred when there is a grandchildren namespace, so We'll make one.
+	rootNs := createNS("root-")
+	parentNs := createSubNS(rootNs, "parent-")
+	childNs := createSubNS(parentNs, "child-")
 	cleanup := func() {
+		MustRunWithTimeout(cleanupTimeout, "kubectl annotate ns", rootNs , "hnc.x-k8s.io/subnamespace-of-")
 		MustRunWithTimeout(cleanupTimeout, "kubectl annotate ns", parentNs, "hnc.x-k8s.io/subnamespace-of-")
 		MustRunWithTimeout(cleanupTimeout, "kubectl annotate ns", childNs, "hnc.x-k8s.io/subnamespace-of-")
 		var wg sync.WaitGroup
-		for _, ns := range []string{parentNs, childNs} {
+		for _, ns := range []string{rootNs, parentNs, childNs} {
 			wg.Add(1)
 			go func(ns string) {
 				MustRun("kubectl delete ns", ns)
@@ -204,8 +207,8 @@ func createNS(prefix string) string {
 	return nsName
 }
 
-func createSubNS(parent string) string {
-	nsName := "hrq-test-child-" + uuid.New().String()
+func createSubNS(parent, prefix string) string {
+	nsName := prefix + uuid.New().String()
 	MustRun("kubectl hns create", nsName, "-n", parent)
 	return nsName
 }


### PR DESCRIPTION
When the following structure is used, if `parent-ns` has hrq, it will consider `root-ns` and cause an error. This is a fix for that.
```
root-ns
- parent-ns
	- child-ns-1
	- child-ns-2
```