### PR TITLE
Show HierarchicalResourceQuota status by kubectl get

### DIFF
--- a/api/v1alpha2/hierarchicalresourcequota_types.go
+++ b/api/v1alpha2/hierarchicalresourcequota_types.go
@@ -48,10 +48,21 @@ type HierarchicalResourceQuotaStatus struct {
 	// and its descendant namespaces.
 	// +optional
 	Used corev1.ResourceList `json:"used,omitempty"`
+	// RequestsSummary is used by kubectl get hrq, and summarizes the relevant information
+	// from .status.hard.requests and .status.used.requests.
+	// +optional
+	RequestsSummary string `json:"requestsSummary,omitempty"`
+	// LimitsSummary is used by kubectl get hrq, and summarizes the relevant information
+	// from .status.hard.limits and .status.used.limits.
+	// +optional
+	LimitsSummary string `json:"limitsSummary,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=hierarchicalresourcequotas,shortName=hrq,scope=Namespaced
+// +kubebuilder:printcolumn:name="REQUEST",type="string",JSONPath=".status.requestsSummary",description="Current usage of resources"
+// +kubebuilder:printcolumn:name="LIMIT",type="string",JSONPath=".status.limitsSummary",description="Resource limits"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 // HierarchicalResourceQuota sets aggregate quota restrictions enforced for a
 // namespace and descendant namespaces

--- a/config/crd/bases/hnc.x-k8s.io_hierarchicalresourcequotas.yaml
+++ b/config/crd/bases/hnc.x-k8s.io_hierarchicalresourcequotas.yaml
@@ -16,7 +16,19 @@ spec:
     singular: hierarchicalresourcequota
   scope: Namespaced
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - description: Current usage of resources
+      jsonPath: .status.requestsSummary
+      name: REQUEST
+      type: string
+    - description: Resource limits
+      jsonPath: .status.limitsSummary
+      name: LIMIT
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: HierarchicalResourceQuota sets aggregate quota restrictions enforced
@@ -99,6 +111,14 @@ spec:
                 description: Hard is the set of enforced hard limits for each named
                   resource
                 type: object
+              limitsSummary:
+                description: LimitsSummary is used by kubectl get hrq, and summarizes
+                  the relevant information from .status.hard.limits and .status.used.limits.
+                type: string
+              requestsSummary:
+                description: RequestsSummary is used by kubectl get hrq, and summarizes
+                  the relevant information from .status.hard.requests and .status.used.requests.
+                type: string
               used:
                 additionalProperties:
                   anyOf:
@@ -113,3 +133,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/internal/hrq/hrqreconciler.go
+++ b/internal/hrq/hrqreconciler.go
@@ -1,8 +1,11 @@
 package hrq
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -14,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	v1 "k8s.io/api/core/v1"
 	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
 	"sigs.k8s.io/hierarchical-namespaces/internal/hrq/utils"
@@ -186,6 +190,32 @@ func (r *HierarchicalResourceQuotaReconciler) syncUsages(inst *api.HierarchicalR
 	}
 	inst.Status.Used = utils.FilterUnlimited(usage, inst.Spec.Hard)
 
+	// Update status.request and status.limit to show HRQ status by using kubectl get
+	resources := make([]v1.ResourceName, 0, len(inst.Status.Hard))
+	for resource := range inst.Status.Hard {
+		resources = append(resources, resource)
+	}
+	sort.Sort(sortableResourceNames(resources))
+
+	requestColumn := bytes.NewBuffer([]byte{})
+	limitColumn := bytes.NewBuffer([]byte{})
+	for i := range resources {
+		w := requestColumn
+		resource := resources[i]
+		usedQuantity := inst.Status.Used[resource]
+		hardQuantity := inst.Status.Hard[resource]
+
+		// use limitColumn writer if a resource name prefixed with "limits" is found
+		if pieces := strings.Split(resource.String(), "."); len(pieces) > 1 && pieces[0] == "limits" {
+			w = limitColumn
+		}
+
+		fmt.Fprintf(w, "%s: %s/%s, ", resource, usedQuantity.String(), hardQuantity.String())
+	}
+
+	inst.Status.RequestsSummary = strings.TrimSuffix(requestColumn.String(), ", ")
+	inst.Status.LimitsSummary = strings.TrimSuffix(limitColumn.String(), ", ")
+
 	return nil
 }
 
@@ -246,4 +276,19 @@ func (r *HierarchicalResourceQuotaReconciler) SetupWithManager(mgr ctrl.Manager)
 		For(&api.HierarchicalResourceQuota{}).
 		Watches(&source.Channel{Source: r.trigger}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
+}
+
+// sortableResourceNames - An array of sortable resource names
+type sortableResourceNames []v1.ResourceName
+
+func (list sortableResourceNames) Len() int {
+	return len(list)
+}
+
+func (list sortableResourceNames) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+func (list sortableResourceNames) Less(i, j int) bool {
+	return list[i] < list[j]
 }

--- a/internal/hrq/hrqreconciler.go
+++ b/internal/hrq/hrqreconciler.go
@@ -200,16 +200,17 @@ func (r *HierarchicalResourceQuotaReconciler) syncUsages(inst *api.HierarchicalR
 	requestColumn := bytes.NewBuffer([]byte{})
 	limitColumn := bytes.NewBuffer([]byte{})
 	for i := range resources {
-		w := requestColumn
 		resource := resources[i]
-		usedQuantity := inst.Status.Used[resource]
-		hardQuantity := inst.Status.Hard[resource]
 
-		// use limitColumn writer if a resource name prefixed with "limits" is found
+		var w *bytes.Buffer
 		if pieces := strings.Split(resource.String(), "."); len(pieces) > 1 && pieces[0] == "limits" {
 			w = limitColumn
+		} else {
+			w = requestColumn
 		}
 
+		usedQuantity := inst.Status.Used[resource]
+		hardQuantity := inst.Status.Hard[resource]
 		fmt.Fprintf(w, "%s: %s/%s, ", resource, usedQuantity.String(), hardQuantity.String())
 	}
 

--- a/test/e2e/hrq_test.go
+++ b/test/e2e/hrq_test.go
@@ -323,6 +323,47 @@ var _ = PDescribe("Hierarchical Resource Quota", Serial, func() {
 	})
 })
 
+var _ = Describe("HRQ Printer Columns Test", Serial, func() {
+	BeforeEach(func() {
+		rand.Seed(time.Now().UnixNano())
+		CleanupTestNamespaces()
+	})
+
+	AfterEach(func() {
+		CleanupTestNamespaces()
+	})
+
+	It("should show HRQ resource usage and limits in kubectl get hrq columns", func() {
+		// set up namespaces
+		CreateNamespace(nsA)
+		CreateSubnamespace(nsB, nsA)
+
+		// Set up HRQs with specific limits
+		setHRQ("printer-test-hrq", nsA, "memory", "200Mi", "cpu", "300m")
+
+		// Create resources that will show up in usage
+		createPod("printer-test-pod", nsB, "memory 100Mi cpu 150m", "memory 50Mi cpu 75m")
+
+		// Wait for resource usage to be recorded
+		FieldShouldContain("hrq", nsA, "printer-test-hrq", ".status.used", "memory:50Mi")
+		FieldShouldContain("hrq", nsA, "printer-test-hrq", ".status.used", "cpu:75m")
+
+		// Now verify that kubectl get hrq shows the columns with correct values
+		RunShouldContain("printer-test-hrq", propagationTime, "kubectl get hrq -n", nsA)
+		RunShouldContain("memory", propagationTime, "kubectl get hrq -n", nsA)
+		RunShouldContain("cpu", propagationTime, "kubectl get hrq -n", nsA)
+
+		// Verify the column headers are present
+		rawOutput, err := RunCommand("kubectl get hrq -n", nsA)
+		Expect(err).Should(BeNil())
+		// The default output should include our printer columns
+		Expect(rawOutput).Should(ContainSubstring("NAME"))
+		Expect(rawOutput).Should(ContainSubstring("REQUEST"))
+		Expect(rawOutput).Should(ContainSubstring("LIMIT"))
+		Expect(rawOutput).Should(ContainSubstring("AGE"))
+	})
+})
+
 func generateHRQManifest(nm, nsnm string, args ...string) string {
 	return `# temp file created by hrq_test.go
 apiVersion: hnc.x-k8s.io/v1alpha2


### PR DESCRIPTION
This feature came from https://github.com/kubernetes-retired/hierarchical-namespaces/pull/295

This feature allows us to see the current limit and request in HRQ with `kubectl get` cmd instead of `kubectl describe` cmd, it'll help with debugging in production.

```
$ kubectl get hrq -n test-hrq
NAME       REQUEST                                              LIMIT                                            AGE
test-hrq   requests.cpu: 200m/1, requests.memory: 100Mi/200Mi   limits.cpu: 200m/2, limits.memory: 100Mi/500Mi   21h
```