### PR TITLE
Update .goreleaser.yaml to include a Kubernetes manifest.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,6 +2,7 @@ version: 2
 before:
   hooks:
   - go mod download
+  - bash -eux -o pipefail -c "mkdir -p releases; cd config/variants/hrq; kustomize edit set image controller=ghcr.io/pfnet/{{ .ProjectName }}:{{ .Version }}; kustomize build . > ../../../releases/hrq.yaml"
 builds:
 - id: manager
   env:
@@ -19,6 +20,9 @@ builds:
   - -a
   ldflags:
   - -s -w -X github.com/pfnet/hierarchical-namespaces/cmd.Version={{.Version}} -X github.com/pfnet/hierarchical-namespaces/cmd.Revision={{.ShortCommit}} -extldflags "-static"
+release:
+  extra_files:
+    - glob: "releases/hrq.yaml"
 
 dockers:
 - image_templates: ["ghcr.io/pfnet/{{ .ProjectName }}:{{ .Version }}-amd64"]


### PR DESCRIPTION
This is the diff between https://github.com/pfnet/hierarchical-namespaces/releases/download/v1.1.0-pfnet.7/hrq.yaml and the manifest generated by this release script:

```diff
--- /Users/ryotarai/Downloads/hrq.yaml  2025-05-26 23:59:16
+++ ./releases/hrq.yaml 2025-05-27 00:22:11
@@ -845,7 +845,7 @@
         - --enable-hrq
         command:
         - /manager
-        image: ghcr.io/pfnet/hierarchical-namespaces:1.1.0-pfnet.7
+        image: ghcr.io/pfnet/hierarchical-namespaces:1.1.0-pfnet.7-SNAPSHOT-fe64d323
         livenessProbe:
           failureThreshold: 1
           httpGet:
@@ -1085,4 +1085,4 @@
     - UPDATE
     resources:
     - namespaces
-  sideEffects: None
\ No newline at end of file
+  sideEffects: None
```