### PR TITLE
Multiple scoped HRQs with the same name

### DIFF
--- a/internal/hrq/hrqreconciler.go
+++ b/internal/hrq/hrqreconciler.go
@@ -96,7 +96,11 @@ func (r *HierarchicalResourceQuotaReconciler) Reconcile(ctx context.Context, req
 
 	rqName := api.ResourceQuotaSingletonName
 	if r.Forest.IsMarkedAsScopedHRQ(req.NamespacedName) {
-		rqName = utils.ScopedRQName(inst.GetName())
+		rqName, err = utils.ScopedRQName(inst.GetNamespace(), inst.GetName())
+		if err != nil {
+			log.Error(err, "Couldn't get the scoped RQ name")
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Enqueue ResourceQuota objects in the current namespace and its descendants
@@ -116,6 +120,8 @@ func (r *HierarchicalResourceQuotaReconciler) Reconcile(ctx context.Context, req
 // forest. The first return value is true if the HRQ object is updated; the
 // second return value is true if the forest is updated.
 func (r *HierarchicalResourceQuotaReconciler) syncWithForest(log logr.Logger, inst *api.HierarchicalResourceQuota) (bool, bool, error) {
+	var err error
+
 	r.Forest.Lock()
 	defer r.Forest.Unlock()
 
@@ -126,10 +132,16 @@ func (r *HierarchicalResourceQuotaReconciler) syncWithForest(log logr.Logger, in
 	if isScopedHRQ {
 		log.Info("Marking HRQ as scoped", "name", inst.GetName(), "namespace", inst.GetNamespace())
 		r.Forest.MarkScopedRQ(nn)
-		rqName = utils.ScopedRQName(inst.GetName())
+		rqName, err = utils.ScopedRQName(inst.GetNamespace(), inst.GetName())
+		if err != nil {
+			return false, false, err
+		}
 	} else if r.Forest.IsMarkedAsScopedHRQ(nn) {
 		log.Info("Detect the Scoped HRQ because of the mark")
-		rqName = utils.ScopedRQName(inst.GetName())
+		rqName, err = utils.ScopedRQName(inst.GetNamespace(), inst.GetName())
+		if err != nil {
+			return false, false, err
+		}
 	} else {
 		log.Info("HRQ is a singleton")
 	}

--- a/internal/hrq/hrqreconciler_test.go
+++ b/internal/hrq/hrqreconciler_test.go
@@ -150,7 +150,11 @@ var _ = Describe("HRQ reconciler tests", func() {
 
 		// Scoped HRQs don't affect the result of TestCheckHRQDrift.
 		forestOverrideSubtreeUsages("hrq-selector", "cpu", "3")
-		updateRQUsage(ctx, fooName, utils.ScopedRQName("hrq-selector"), "cpu", "5")
+
+		scopedRQ, err := utils.ScopedRQName(fooName, "hrq-selector")
+		Expect(err).NotTo(HaveOccurred())
+		updateRQUsage(ctx, fooName, scopedRQ, "cpu", "5")
+
 		drift, err = TestCheckHRQDrift()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(drift).Should(BeFalse())

--- a/internal/hrq/rqreconciler.go
+++ b/internal/hrq/rqreconciler.go
@@ -107,16 +107,18 @@ func (r *ResourceQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	log.Info("Reconciling ResourceQuota", "name", fmt.Sprintf("%s/%s", inst.GetNamespace(), inst.GetName()), "limits", inst.Spec.Hard, "usages", inst.Status.Used, "updated", updated)
 
+	var hrq *api.HierarchicalResourceQuota
+
 	// Delete the obsolete singleton and early exit if the new limits are empty.
 	if inst.Spec.Hard == nil {
 		return ctrl.Result{}, r.deleteRQ(ctx, log, inst)
 	} else if !isSingleton && notFound {
-		hrq := &api.HierarchicalResourceQuota{}
-		hrqnnm, err := utils.ScopedHRQNameFromRQName(inst.Name)
+		hrqnnm, err := r.findHRQNameForRQ(inst)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("while getting hrq name: %w", err)
+			return ctrl.Result{}, fmt.Errorf("while finding hrq name for new RQ: %w", err)
 		}
 
+		hrq = &api.HierarchicalResourceQuota{}
 		err = r.Get(ctx, hrqnnm, hrq)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -129,6 +131,9 @@ func (r *ResourceQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		log.Info("Found the parent HRQ", "namespace", hrq.Namespace, "name", hrq.Name)
 
 		inst.Spec.ScopeSelector = hrq.Spec.ScopeSelector
+		metadata.SetLabel(inst, utils.HRQNameLabel, hrq.Name)
+		metadata.SetLabel(inst, utils.HRQNamespaceLabel, hrq.Namespace)
+		metadata.SetAnnotation(inst, utils.NewScopedRQAnnotation, "true")
 	}
 
 	// We only need to write back to the apiserver if the spec has changed
@@ -158,6 +163,7 @@ func (r *ResourceQuotaReconciler) writeRQ(ctx context.Context, log logr.Logger, 
 	if inst.CreationTimestamp.IsZero() {
 		// Set the cleanup label so the singleton can be deleted by selector later.
 		metadata.SetLabel(inst, api.HRQLabelCleanup, "true")
+
 		// Add a non-propagate exception annotation to the instance so that it won't
 		// be overwritten by ancestors, when the resource quota type is configured
 		// as Propagate mode in HNCConfig.
@@ -219,6 +225,38 @@ func (r *ResourceQuotaReconciler) getAncestorHRQs(inst *v1.ResourceQuota) []type
 	}
 
 	return names
+}
+
+// findHRQNameForRQ finds HRQ name and namespace for a new RQ by searching through namespace and ancestor HRQs
+func (r *ResourceQuotaReconciler) findHRQNameForRQ(inst *v1.ResourceQuota) (types.NamespacedName, error) {
+	hrqnnm, err := utils.ScopedHRQNameFromRQ(inst)
+	if err == nil {
+		return hrqnnm, nil
+	}
+
+	// New RQs that don't have the labels yet, so we need to search through the forest
+	r.Forest.Lock()
+	defer r.Forest.Unlock()
+
+	ns := r.Forest.Get(inst.Namespace)
+
+	// Check current namespace and all ancestors
+	namespaces := []string{inst.Namespace}
+	namespaces = append(namespaces, ns.AncestryNames()...)
+
+	for _, nsnm := range namespaces {
+		ancestorNS := r.Forest.Get(nsnm)
+		for _, hrqName := range ancestorNS.HRQNames() {
+			expectedRQName, err := utils.ScopedRQName(nsnm, hrqName)
+			if err != nil {
+				continue
+			}
+			if expectedRQName == inst.Name {
+				return types.NamespacedName{Namespace: nsnm, Name: hrqName}, nil
+			}
+		}
+	}
+	return types.NamespacedName{}, fmt.Errorf("no matching HRQ found for RQ: %s", inst.Name)
 }
 
 // deleteRQ deletes a resource quota on the apiserver and a quota in on-memory if it exists. Otherwise,

--- a/internal/hrq/rqreconciler.go
+++ b/internal/hrq/rqreconciler.go
@@ -167,7 +167,6 @@ func (r *ResourceQuotaReconciler) writeRQ(ctx context.Context, log logr.Logger, 
 	if inst.CreationTimestamp.IsZero() {
 		// Set the cleanup label so the singleton can be deleted by selector later.
 		metadata.SetLabel(inst, api.HRQLabelCleanup, "true")
-
 		// Add a non-propagate exception annotation to the instance so that it won't
 		// be overwritten by ancestors, when the resource quota type is configured
 		// as Propagate mode in HNCConfig.
@@ -347,7 +346,7 @@ func (r *ResourceQuotaReconciler) syncResourceLimits(ns *forest.Namespace, inst 
 	return true
 }
 
-// migrateLegacyScopedRQ handles migration from legacy scoped RQ format to new format
+// deleteLegacyScopedRQ deletes the legacy scoped RQ if it exists.
 func (r *ResourceQuotaReconciler) deleteLegacyScopedRQ(ctx context.Context, log logr.Logger, newRQ *v1.ResourceQuota) error {
 	hrqnnm, err := utils.ScopedHRQNameFromRQ(newRQ)
 	if err != nil {

--- a/internal/hrq/rqreconciler.go
+++ b/internal/hrq/rqreconciler.go
@@ -369,33 +369,6 @@ func (r *ResourceQuotaReconciler) deleteLegacyScopedRQ(ctx context.Context, log 
 	return r.deleteRQ(ctx, log, legacyRQ)
 }
 
-// // findHRQForMigration finds the HRQ that corresponds to the legacy RQ
-// func (r *ResourceQuotaReconciler) findHRQForMigration(ctx context.Context, log logr.Logger, namespace, hrqName string) (*api.HierarchicalResourceQuota, error) {
-// 	r.Forest.Lock()
-// 	ns := r.Forest.Get(namespace)
-// 	ancestryNames := ns.AncestryNames()
-// 	r.Forest.Unlock()
-
-// 	for _, nsnm := range ancestryNames {
-// 		hrq := &api.HierarchicalResourceQuota{}
-// 		hrqKey := types.NamespacedName{Namespace: nsnm, Name: hrqName}
-// 		log.Info("Checking HRQ for migration", "hrqNamespace", nsnm, "hrqName", hrqName)
-
-// 		err := r.Get(ctx, hrqKey, hrq)
-// 		if err == nil && hrq.Spec.ScopeSelector != nil {
-// 			// Found scoped HRQ
-// 			log.Info("Found HRQ for migration", "hrqNamespace", nsnm, "hrqName", hrqName)
-// 			return hrq, nil
-// 		}
-
-// 		if err != nil && !apierrors.IsNotFound(err) {
-// 			return nil, fmt.Errorf("error checking HRQ %s/%s: %w", nsnm, hrqName, err)
-// 		}
-// 	}
-
-// 	return nil, nil
-// }
-
 // OnChangeNamespace enqueues the singleton in a specific namespace to trigger the reconciliation of
 // the singleton for a given reason .  This occurs in a goroutine so the caller doesn't block; since
 // the reconciler is never garbage-collected, this is safe.

--- a/internal/hrq/rqreconciler.go
+++ b/internal/hrq/rqreconciler.go
@@ -105,33 +105,18 @@ func (r *ResourceQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, r.deleteRQ(ctx, log, inst)
 	} else if !isSingleton && notFound {
 		hrq := &api.HierarchicalResourceQuota{}
-		hrqName, err := utils.ScopedHRQNameFromHRQName(inst.Name)
+		hrqnnm, err := utils.ScopedHRQNameFromRQName(inst.Name)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("while getting hrq name: %w", err)
 		}
 
-		cursorNm := ns
-		var found bool
-		for {
-			if cursorNm == nil {
-				break
-			}
-
-			hrqnnm := types.NamespacedName{Namespace: cursorNm.Name(), Name: hrqName}
-			err := r.Get(ctx, hrqnnm, hrq)
-			if err == nil {
-				found = true
-				break
-			}
+		err = r.Get(ctx, hrqnnm, hrq)
+		if err != nil {
 			if apierrors.IsNotFound(err) {
-				cursorNm = cursorNm.Parent()
-				continue
+				return ctrl.Result{}, fmt.Errorf("the parent hrq not found: %s", hrqnnm)
+			} else {
+				return ctrl.Result{}, fmt.Errorf("getting hrq %s: %w", hrqnnm, err)
 			}
-
-			return ctrl.Result{}, fmt.Errorf("while getting hrq: %w", err)
-		}
-		if !found {
-			return ctrl.Result{}, fmt.Errorf("the parent hrq not found: %s", hrqName)
 		}
 
 		log.Info("Found the parent HRQ", "namespace", hrq.Namespace, "name", hrq.Name)

--- a/internal/hrq/rqreconciler.go
+++ b/internal/hrq/rqreconciler.go
@@ -305,65 +305,6 @@ func (r *ResourceQuotaReconciler) syncResourceLimits(ns *forest.Namespace, inst 
 	return true
 }
 
-// OnChangeNamespace enqueues the singleton in a specific namespace to trigger the reconciliation of
-// the singleton for a given reason .  This occurs in a goroutine so the caller doesn't block; since
-// the reconciler is never garbage-collected, this is safe.
-func (r *ResourceQuotaReconciler) OnChangeNamespace(log logr.Logger, ns *forest.Namespace) {
-	for _, nm := range ns.RQNames() {
-		r.OnChangeNamespaceWithRQName(log, ns, nm)
-	}
-}
-
-func (r *ResourceQuotaReconciler) OnChangeNamespaceWithRQName(log logr.Logger, ns *forest.Namespace, name string) {
-	nsnm := ns.Name()
-	go func() {
-		// The watch handler doesn't care about anything except the metadata.
-		inst := &v1.ResourceQuota{}
-		inst.ObjectMeta.Name = name
-		inst.ObjectMeta.Namespace = nsnm
-		r.trigger <- event.GenericEvent{Object: inst}
-	}()
-}
-
-// EnqueueSubtree enqueues ResourceQuota objects of the given namespace and its descendants.
-//
-// The method is robust against race conditions. The method holds the forest lock so that the
-// in-memory forest (specifically the descendants of the namespace that we record in-memory) cannot
-// be changed while enqueueing ResourceQuota objects in the namespace and its descendants.
-//
-// If a new namespace becomes a descendant just after we acquire the lock, the ResourceQuota object
-// in the new namespace will be enqueued by the NamespaceReconciler, instead of the
-// ResourceQuotaReconciler. By contrast, if a namespace is *removed* as a descendant, we'll still
-// call the reconciler but it will have no effect (reconcilers can safely be called multiple times,
-// even if the object has been deleted).
-func (r *ResourceQuotaReconciler) EnqueueSubtree(log logr.Logger, nsnm, name string, deleted bool) {
-	r.Forest.Lock()
-	defer r.Forest.Unlock()
-
-	nsnms := r.Forest.Get(nsnm).DescendantNames()
-	nsnms = append(nsnms, nsnm)
-	for _, nsnm := range nsnms {
-		ns := r.Forest.Get(nsnm)
-		if !deleted {
-			if _, ok := ns.GetQuota(name); !ok {
-				ns.SetQuota(name)
-			}
-		}
-		r.OnChangeNamespaceWithRQName(log, ns, name)
-	}
-}
-
-func (r *ResourceQuotaReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// This field will be shown as source.component=hnc.x-k8s.io in events.
-	r.eventRecorder = mgr.GetEventRecorderFor(api.MetaGroup)
-	r.trigger = make(chan event.GenericEvent)
-
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1.ResourceQuota{}).
-		WatchesRawSource(source.Channel(r.trigger, &handler.EnqueueRequestForObject{})).
-		Complete(r)
-}
-
 // migrateLegacyScopedRQ handles migration from legacy scoped RQ format to new format
 func (r *ResourceQuotaReconciler) migrateLegacyScopedRQ(ctx context.Context, log logr.Logger, legacyRQ *v1.ResourceQuota) (ctrl.Result, error) {
 	// Double-check that this is actually an HNC-managed legacy RQ
@@ -446,4 +387,63 @@ func (r *ResourceQuotaReconciler) findHRQForMigration(ctx context.Context, log l
 	}
 
 	return nil, nil
+}
+
+// OnChangeNamespace enqueues the singleton in a specific namespace to trigger the reconciliation of
+// the singleton for a given reason .  This occurs in a goroutine so the caller doesn't block; since
+// the reconciler is never garbage-collected, this is safe.
+func (r *ResourceQuotaReconciler) OnChangeNamespace(log logr.Logger, ns *forest.Namespace) {
+	for _, nm := range ns.RQNames() {
+		r.OnChangeNamespaceWithRQName(log, ns, nm)
+	}
+}
+
+func (r *ResourceQuotaReconciler) OnChangeNamespaceWithRQName(log logr.Logger, ns *forest.Namespace, name string) {
+	nsnm := ns.Name()
+	go func() {
+		// The watch handler doesn't care about anything except the metadata.
+		inst := &v1.ResourceQuota{}
+		inst.ObjectMeta.Name = name
+		inst.ObjectMeta.Namespace = nsnm
+		r.trigger <- event.GenericEvent{Object: inst}
+	}()
+}
+
+// EnqueueSubtree enqueues ResourceQuota objects of the given namespace and its descendants.
+//
+// The method is robust against race conditions. The method holds the forest lock so that the
+// in-memory forest (specifically the descendants of the namespace that we record in-memory) cannot
+// be changed while enqueueing ResourceQuota objects in the namespace and its descendants.
+//
+// If a new namespace becomes a descendant just after we acquire the lock, the ResourceQuota object
+// in the new namespace will be enqueued by the NamespaceReconciler, instead of the
+// ResourceQuotaReconciler. By contrast, if a namespace is *removed* as a descendant, we'll still
+// call the reconciler but it will have no effect (reconcilers can safely be called multiple times,
+// even if the object has been deleted).
+func (r *ResourceQuotaReconciler) EnqueueSubtree(log logr.Logger, nsnm, name string, deleted bool) {
+	r.Forest.Lock()
+	defer r.Forest.Unlock()
+
+	nsnms := r.Forest.Get(nsnm).DescendantNames()
+	nsnms = append(nsnms, nsnm)
+	for _, nsnm := range nsnms {
+		ns := r.Forest.Get(nsnm)
+		if !deleted {
+			if _, ok := ns.GetQuota(name); !ok {
+				ns.SetQuota(name)
+			}
+		}
+		r.OnChangeNamespaceWithRQName(log, ns, name)
+	}
+}
+
+func (r *ResourceQuotaReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// This field will be shown as source.component=hnc.x-k8s.io in events.
+	r.eventRecorder = mgr.GetEventRecorderFor(api.MetaGroup)
+	r.trigger = make(chan event.GenericEvent)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1.ResourceQuota{}).
+		WatchesRawSource(source.Channel(r.trigger, &handler.EnqueueRequestForObject{})).
+		Complete(r)
 }

--- a/internal/hrq/rqreconciler.go
+++ b/internal/hrq/rqreconciler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
@@ -83,6 +84,12 @@ func (r *ResourceQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	isSingleton := utils.IsSingletonRQ(inst)
+	isLegacyScoped := utils.IsLegacyScopedRQ(inst)
+
+	// Handle migration from legacy scoped RQ to new format
+	if !notFound && isLegacyScoped {
+		return r.migrateLegacyScopedRQ(ctx, log, inst)
+	}
 
 	r.Forest.Lock()
 	ns := r.Forest.Get(inst.ObjectMeta.Namespace)
@@ -355,4 +362,88 @@ func (r *ResourceQuotaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&v1.ResourceQuota{}).
 		WatchesRawSource(source.Channel(r.trigger, &handler.EnqueueRequestForObject{})).
 		Complete(r)
+}
+
+// migrateLegacyScopedRQ handles migration from legacy scoped RQ format to new format
+func (r *ResourceQuotaReconciler) migrateLegacyScopedRQ(ctx context.Context, log logr.Logger, legacyRQ *v1.ResourceQuota) (ctrl.Result, error) {
+	// Double-check that this is actually an HNC-managed legacy RQ
+	if !utils.IsHNCManagedRQ(legacyRQ) {
+		log.Info("Skipping migration for non-HNC managed RQ", "rqName", legacyRQ.Name)
+		return ctrl.Result{}, nil
+	}
+
+	// Extract HRQ name from legacy RQ name
+	hrqName, err := utils.HRQNameFromLegacyRQName(legacyRQ.Name)
+	if err != nil {
+		log.Error(err, "Failed to extract HRQ name from legacy RQ", "rqName", legacyRQ.Name)
+		return ctrl.Result{}, err
+	}
+
+	// Find the corresponding HRQ in current namespace or ancestors
+	hrq, err := r.findHRQForMigration(ctx, log, legacyRQ.Namespace, hrqName)
+	if err != nil {
+		log.Error(err, "Failed to find HRQ for migration", "hrqName", hrqName)
+		return ctrl.Result{}, err
+	}
+
+	if hrq == nil {
+		// No corresponding HRQ found, delete the legacy RQ
+		log.Info("No corresponding HRQ found, deleting legacy RQ", "rqName", legacyRQ.Name)
+		return ctrl.Result{}, r.deleteRQ(ctx, log, legacyRQ)
+	}
+
+	// Generate new RQ name
+	newRQName, err := utils.ScopedRQName(hrq.Namespace, hrq.Name)
+	if err != nil {
+		log.Error(err, "Failed to generate new RQ name")
+		return ctrl.Result{}, err
+	}
+
+	// Check if new RQ already exists
+	_, err = r.getRQ(ctx, legacyRQ.Namespace, newRQName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		log.Error(err, "Failed to check new RQ existence")
+		return ctrl.Result{}, err
+	}
+
+	if apierrors.IsNotFound(err) {
+		// New RQ doesn't exist yet - the normal reconcile process will create it
+		// Requeue after a short delay to check again
+		log.Info("New format RQ not yet created, requeuing for retry", "legacyName", legacyRQ.Name, "expectedNewName", newRQName)
+		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+	}
+
+	// New RQ exists, safe to delete legacy RQ
+	log.Info("New format RQ exists, deleting legacy RQ", "legacyName", legacyRQ.Name, "newName", newRQName)
+	return ctrl.Result{}, r.deleteRQ(ctx, log, legacyRQ)
+}
+
+// findHRQForMigration finds the HRQ that corresponds to the legacy RQ
+func (r *ResourceQuotaReconciler) findHRQForMigration(ctx context.Context, log logr.Logger, namespace, hrqName string) (*api.HierarchicalResourceQuota, error) {
+	r.Forest.Lock()
+	ns := r.Forest.Get(namespace)
+	ancestryNames := ns.AncestryNames()
+	r.Forest.Unlock()
+
+	// Check current namespace first, then ancestors
+	namespaces := []string{namespace}
+	namespaces = append(namespaces, ancestryNames...)
+
+	for _, nsnm := range namespaces {
+		hrq := &api.HierarchicalResourceQuota{}
+		hrqKey := types.NamespacedName{Namespace: nsnm, Name: hrqName}
+
+		err := r.Get(ctx, hrqKey, hrq)
+		if err == nil && hrq.Spec.ScopeSelector != nil {
+			// Found scoped HRQ
+			log.Info("Found HRQ for migration", "hrqNamespace", nsnm, "hrqName", hrqName)
+			return hrq, nil
+		}
+
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("error checking HRQ %s/%s: %w", nsnm, hrqName, err)
+		}
+	}
+
+	return nil, nil
 }

--- a/internal/hrq/rqreconciler.go
+++ b/internal/hrq/rqreconciler.go
@@ -364,9 +364,8 @@ func (r *ResourceQuotaReconciler) migrateLegacyScopedRQ(ctx context.Context, log
 	}
 
 	if hrq == nil {
-		// No corresponding HRQ found, delete the legacy RQ
-		log.Info("No corresponding HRQ found, deleting legacy RQ", "rqName", legacyRQ.Name)
-		return ctrl.Result{}, r.deleteRQ(ctx, log, legacyRQ)
+		log.Info("No corresponding HRQ found for legacy RQ", "namespace", legacyRQ.Namespace, "rqName", legacyRQ.Name, "hrqName", hrqName)
+		return ctrl.Result{}, nil
 	}
 
 	// Generate new RQ name
@@ -378,16 +377,16 @@ func (r *ResourceQuotaReconciler) migrateLegacyScopedRQ(ctx context.Context, log
 
 	// Check if new RQ already exists
 	_, err = r.getRQ(ctx, legacyRQ.Namespace, newRQName)
-	if err != nil && !apierrors.IsNotFound(err) {
-		log.Error(err, "Failed to check new RQ existence")
-		return ctrl.Result{}, err
-	}
-
-	if apierrors.IsNotFound(err) {
-		// New RQ doesn't exist yet - the normal reconcile process will create it
-		// Requeue after a short delay to check again
-		log.Info("New format RQ not yet created, requeuing for retry", "legacyName", legacyRQ.Name, "expectedNewName", newRQName)
-		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// New RQ doesn't exist yet - the normal reconcile process will create it
+			// Requeue after a short delay to check again
+			log.Info("New format RQ not yet created, requeuing for retry", "legacyName", legacyRQ.Name, "expectedNewName", newRQName)
+			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+		} else {
+			log.Error(err, "Failed to check new RQ existence")
+			return ctrl.Result{}, err
+		}
 	}
 
 	// New RQ exists, safe to delete legacy RQ

--- a/internal/hrq/rqreconciler.go
+++ b/internal/hrq/rqreconciler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
@@ -86,9 +85,16 @@ func (r *ResourceQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	isSingleton := utils.IsSingletonRQ(inst)
 	isLegacyScoped := utils.IsLegacyScopedRQ(inst)
 
-	// Handle migration from legacy scoped RQ to new format
-	if !notFound && isLegacyScoped {
-		return r.migrateLegacyScopedRQ(ctx, log, inst)
+	if isLegacyScoped {
+		// Ignore legacy scoped RQs
+		// It will be deleted in the reconcile loop for the new RQ.
+		return ctrl.Result{}, nil
+	}
+
+	if !notFound && !isSingleton { // scoped RQ exists
+		if err := r.deleteLegacyScopedRQ(ctx, log, inst); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	r.Forest.Lock()
@@ -342,87 +348,53 @@ func (r *ResourceQuotaReconciler) syncResourceLimits(ns *forest.Namespace, inst 
 }
 
 // migrateLegacyScopedRQ handles migration from legacy scoped RQ format to new format
-func (r *ResourceQuotaReconciler) migrateLegacyScopedRQ(ctx context.Context, log logr.Logger, legacyRQ *v1.ResourceQuota) (ctrl.Result, error) {
-	// Double-check that this is actually an HNC-managed legacy RQ
-	if !utils.IsHNCManagedRQ(legacyRQ) {
-		log.Info("Skipping migration for non-HNC managed RQ", "rqName", legacyRQ.Name)
-		return ctrl.Result{}, nil
-	}
-
-	// Extract HRQ name from legacy RQ name
-	hrqName, err := utils.HRQNameFromLegacyRQName(legacyRQ.Name)
+func (r *ResourceQuotaReconciler) deleteLegacyScopedRQ(ctx context.Context, log logr.Logger, newRQ *v1.ResourceQuota) error {
+	hrqnnm, err := utils.ScopedHRQNameFromRQ(newRQ)
 	if err != nil {
-		log.Error(err, "Failed to extract HRQ name from legacy RQ", "rqName", legacyRQ.Name)
-		return ctrl.Result{}, err
+		return fmt.Errorf("get HRQ name from RQ: %w", err)
 	}
 
-	// Find the corresponding HRQ in current namespace or ancestors
-	hrq, err := r.findHRQForMigration(ctx, log, legacyRQ.Namespace, hrqName)
-	if err != nil {
-		log.Error(err, "Failed to find HRQ for migration", "hrqName", hrqName)
-		return ctrl.Result{}, err
-	}
+	legacyRQName := utils.LegacyScopedRQName(hrqnnm.Name)
 
-	if hrq == nil {
-		log.Info("No corresponding HRQ found for legacy RQ", "namespace", legacyRQ.Namespace, "rqName", legacyRQ.Name, "hrqName", hrqName)
-		return ctrl.Result{}, nil
-	}
-
-	// Generate new RQ name
-	newRQName, err := utils.ScopedRQName(hrq.Namespace, hrq.Name)
-	if err != nil {
-		log.Error(err, "Failed to generate new RQ name")
-		return ctrl.Result{}, err
-	}
-
-	// Check if new RQ already exists
-	_, err = r.getRQ(ctx, legacyRQ.Namespace, newRQName)
+	legacyRQ, err := r.getRQ(ctx, newRQ.Namespace, legacyRQName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// New RQ doesn't exist yet - the normal reconcile process will create it
-			// Requeue after a short delay to check again
-			log.Info("New format RQ not yet created, requeuing for retry", "legacyName", legacyRQ.Name, "expectedNewName", newRQName)
-			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+			return nil
 		} else {
-			log.Error(err, "Failed to check new RQ existence")
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
-	// New RQ exists, safe to delete legacy RQ
-	log.Info("New format RQ exists, deleting legacy RQ", "legacyName", legacyRQ.Name, "newName", newRQName)
-	return ctrl.Result{}, r.deleteRQ(ctx, log, legacyRQ)
+	log.Info("Deleting legacy scoped RQ", "legacyRQ", legacyRQ.Name, "namespace", legacyRQ.Namespace)
+	return r.deleteRQ(ctx, log, legacyRQ)
 }
 
-// findHRQForMigration finds the HRQ that corresponds to the legacy RQ
-func (r *ResourceQuotaReconciler) findHRQForMigration(ctx context.Context, log logr.Logger, namespace, hrqName string) (*api.HierarchicalResourceQuota, error) {
-	r.Forest.Lock()
-	ns := r.Forest.Get(namespace)
-	ancestryNames := ns.AncestryNames()
-	r.Forest.Unlock()
+// // findHRQForMigration finds the HRQ that corresponds to the legacy RQ
+// func (r *ResourceQuotaReconciler) findHRQForMigration(ctx context.Context, log logr.Logger, namespace, hrqName string) (*api.HierarchicalResourceQuota, error) {
+// 	r.Forest.Lock()
+// 	ns := r.Forest.Get(namespace)
+// 	ancestryNames := ns.AncestryNames()
+// 	r.Forest.Unlock()
 
-	// Check current namespace first, then ancestors
-	namespaces := []string{namespace}
-	namespaces = append(namespaces, ancestryNames...)
+// 	for _, nsnm := range ancestryNames {
+// 		hrq := &api.HierarchicalResourceQuota{}
+// 		hrqKey := types.NamespacedName{Namespace: nsnm, Name: hrqName}
+// 		log.Info("Checking HRQ for migration", "hrqNamespace", nsnm, "hrqName", hrqName)
 
-	for _, nsnm := range namespaces {
-		hrq := &api.HierarchicalResourceQuota{}
-		hrqKey := types.NamespacedName{Namespace: nsnm, Name: hrqName}
+// 		err := r.Get(ctx, hrqKey, hrq)
+// 		if err == nil && hrq.Spec.ScopeSelector != nil {
+// 			// Found scoped HRQ
+// 			log.Info("Found HRQ for migration", "hrqNamespace", nsnm, "hrqName", hrqName)
+// 			return hrq, nil
+// 		}
 
-		err := r.Get(ctx, hrqKey, hrq)
-		if err == nil && hrq.Spec.ScopeSelector != nil {
-			// Found scoped HRQ
-			log.Info("Found HRQ for migration", "hrqNamespace", nsnm, "hrqName", hrqName)
-			return hrq, nil
-		}
+// 		if err != nil && !apierrors.IsNotFound(err) {
+// 			return nil, fmt.Errorf("error checking HRQ %s/%s: %w", nsnm, hrqName, err)
+// 		}
+// 	}
 
-		if err != nil && !apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("error checking HRQ %s/%s: %w", nsnm, hrqName, err)
-		}
-	}
-
-	return nil, nil
-}
+// 	return nil, nil
+// }
 
 // OnChangeNamespace enqueues the singleton in a specific namespace to trigger the reconciliation of
 // the singleton for a given reason .  This occurs in a goroutine so the caller doesn't block; since

--- a/internal/hrq/rqreconciler.go
+++ b/internal/hrq/rqreconciler.go
@@ -131,9 +131,7 @@ func (r *ResourceQuotaReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		log.Info("Found the parent HRQ", "namespace", hrq.Namespace, "name", hrq.Name)
 
 		inst.Spec.ScopeSelector = hrq.Spec.ScopeSelector
-		metadata.SetLabel(inst, utils.HRQNameLabel, hrq.Name)
-		metadata.SetLabel(inst, utils.HRQNamespaceLabel, hrq.Namespace)
-		metadata.SetAnnotation(inst, utils.NewScopedRQAnnotation, "true")
+		utils.SetLabelsAnnotationsForScopedRQ(inst, hrq.Namespace, hrq.Name)
 	}
 
 	// We only need to write back to the apiserver if the spec has changed

--- a/internal/hrq/rqreconciler_test.go
+++ b/internal/hrq/rqreconciler_test.go
@@ -68,7 +68,8 @@ var _ = Describe("RQ reconciler tests", func() {
 		setHRQ(ctx, barHRQName, barName, nil, "secrets", "100", "cpu", "50")
 		setHRQ(ctx, bazHRQName, bazName, nil, "pods", "1")
 		hrqWithSelectorName := "hrq-with-selector"
-		rqName := fmt.Sprintf("%s-%s", api.ResourceQuotaSingletonName, hrqWithSelectorName)
+		rqName, err := utils.ScopedRQName(fooName, hrqWithSelectorName)
+		Expect(err).NotTo(HaveOccurred())
 		setHRQ(ctx, hrqWithSelectorName, fooName, &highPrioritySelector, "cpu", "4", "pods", "2")
 
 		Eventually(getRQHard(ctx, fooName, api.ResourceQuotaSingletonName)).Should(equalRL("secrets", "6", "pods", "3"))
@@ -89,7 +90,8 @@ var _ = Describe("RQ reconciler tests", func() {
 		setHRQ(ctx, bazHRQName, bazName, nil, "pods", "1")
 
 		hrqWithSelectorName := "hrq-with-selector"
-		rqName := fmt.Sprintf("%s-%s", api.ResourceQuotaSingletonName, hrqWithSelectorName)
+		rqName, err := utils.ScopedRQName(fooName, hrqWithSelectorName)
+		Expect(err).NotTo(HaveOccurred())
 		setHRQ(ctx, hrqWithSelectorName, fooName, &highPrioritySelector, "cpu", "6", "pods", "3")
 		setHRQ(ctx, hrqWithSelectorName, barName, &highPrioritySelector, "cpu", "100", "pods", "50")
 		setHRQ(ctx, hrqWithSelectorName, bazName, &highPrioritySelector, "pods", "1")

--- a/internal/hrq/utils/scopedhrq.go
+++ b/internal/hrq/utils/scopedhrq.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/metadata"
 )
 
 func IsSingletonRQ(rq *v1.ResourceQuota) bool {
@@ -16,6 +17,49 @@ func IsSingletonRQ(rq *v1.ResourceQuota) bool {
 
 func IsScopedRQ(rq *v1.ResourceQuota) bool {
 	return !IsSingletonRQ(rq)
+}
+
+// IsHNCManagedRQ checks if an RQ has the HNC cleanup label
+func IsHNCManagedRQ(rq *v1.ResourceQuota) bool {
+	if label, ok := metadata.GetLabel(rq, api.HRQLabelCleanup); ok {
+		return label == "true"
+	}
+	return false
+}
+
+// IsLegacyScopedRQ checks if an RQ is a legacy scoped RQ (old format without namespace)
+// and is managed by HNC
+func IsLegacyScopedRQ(rq *v1.ResourceQuota) bool {
+	if IsSingletonRQ(rq) {
+		return false
+	}
+	// Only consider RQs managed by HNC for migration
+	if !IsHNCManagedRQ(rq) {
+		return false
+	}
+	// Legacy format: hnc-singleton-hrqname (no namespace part)
+	// New format: hnc-singleton-namespace--hrqname
+	trimmed := strings.TrimPrefix(rq.Name, api.ResourceQuotaSingletonName+"-")
+	return !strings.Contains(trimmed, "--")
+}
+
+// LegacyScopedRQName generates the legacy RQ name for backward compatibility
+func LegacyScopedRQName(hrqName string) string {
+	return api.ResourceQuotaSingletonName + "-" + hrqName
+}
+
+// HRQNameFromLegacyRQName extracts HRQ name from legacy RQ name
+func HRQNameFromLegacyRQName(rqName string) (string, error) {
+	if rqName == api.ResourceQuotaSingletonName {
+		return "", fmt.Errorf("invalid legacy RQ name: %s", rqName)
+	}
+
+	hrqName := strings.TrimPrefix(rqName, api.ResourceQuotaSingletonName+"-")
+	if hrqName == rqName {
+		return "", fmt.Errorf("not a legacy scoped RQ name: %s", rqName)
+	}
+
+	return hrqName, nil
 }
 
 func ScopedRQName(hrqNamespace string, hrqName string) (string, error) {

--- a/internal/hrq/utils/scopedhrq.go
+++ b/internal/hrq/utils/scopedhrq.go
@@ -1,14 +1,25 @@
 package utils
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-
 	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 	"sigs.k8s.io/hierarchical-namespaces/internal/metadata"
+)
+
+const (
+	HRQNameLabel          = "hnc.x-k8s.io/hrq-name"
+	HRQNamespaceLabel     = "hnc.x-k8s.io/hrq-namespace"
+	NewScopedRQAnnotation = "hnc.x-k8s.io/new-scoped-rq"
+)
+
+const (
+	maxRQNameLength = 253
 )
 
 func IsSingletonRQ(rq *v1.ResourceQuota) bool {
@@ -37,10 +48,10 @@ func IsLegacyScopedRQ(rq *v1.ResourceQuota) bool {
 	if !IsHNCManagedRQ(rq) {
 		return false
 	}
-	// Legacy format: hnc-singleton-hrqname (no namespace part)
-	// New format: hnc-singleton-namespace--hrqname
-	trimmed := strings.TrimPrefix(rq.Name, api.ResourceQuotaSingletonName+"-")
-	return !strings.Contains(trimmed, "--")
+	if v, ok := metadata.GetAnnotation(rq, NewScopedRQAnnotation); ok && v == "true" {
+		return false
+	}
+	return true
 }
 
 // LegacyScopedRQName generates the legacy RQ name for backward compatibility
@@ -63,21 +74,26 @@ func HRQNameFromLegacyRQName(rqName string) (string, error) {
 }
 
 func ScopedRQName(hrqNamespace string, hrqName string) (string, error) {
-	if strings.Contains(hrqNamespace, "--") {
-		return "", fmt.Errorf("hrq namespace cannot contain '--': %s", hrqNamespace)
-	}
-	return api.ResourceQuotaSingletonName + "-" + hrqNamespace + "--" + hrqName, nil
+	hash := md5.Sum([]byte(fmt.Sprintf("%s/%s", hrqNamespace, hrqName)))
+	hashStr := hex.EncodeToString(hash[:])
+
+	namespaceAndName := truncate(fmt.Sprintf("%s-%s", hrqNamespace, hrqName), maxRQNameLength-len(hashStr)-len(api.ResourceQuotaSingletonName)-2)
+
+	return fmt.Sprintf("%s-%s-%s", api.ResourceQuotaSingletonName, namespaceAndName, hashStr), nil
 }
 
-func ScopedHRQNameFromRQName(rqName string) (types.NamespacedName, error) {
-	if rqName == api.ResourceQuotaSingletonName {
-		return types.NamespacedName{}, fmt.Errorf("invalid RQ name for ScopedHRQ name: %s", rqName)
+func ScopedHRQNameFromRQ(rq *v1.ResourceQuota) (types.NamespacedName, error) {
+	namespace, nsOK := metadata.GetLabel(rq, HRQNamespaceLabel)
+	name, nameOK := metadata.GetLabel(rq, HRQNameLabel)
+	if nsOK && nameOK {
+		return types.NamespacedName{Namespace: namespace, Name: name}, nil
 	}
+	return types.NamespacedName{}, fmt.Errorf("no matching HRQ found for RQ: %s", rq.Name)
+}
 
-	parts := strings.SplitN(strings.TrimPrefix(rqName, api.ResourceQuotaSingletonName+"-"), "--", 2)
-	if len(parts) != 2 {
-		return types.NamespacedName{}, fmt.Errorf("invalid RQ name for ScopedHRQ: %s", rqName)
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
 	}
-
-	return types.NamespacedName{Namespace: parts[0], Name: parts[1]}, nil
+	return s[:n]
 }

--- a/internal/hrq/utils/scopedhrq.go
+++ b/internal/hrq/utils/scopedhrq.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
@@ -17,15 +18,22 @@ func IsScopedRQ(rq *v1.ResourceQuota) bool {
 	return !IsSingletonRQ(rq)
 }
 
-func ScopedRQName(hrqName string) string {
-	return api.ResourceQuotaSingletonName + "-" + hrqName
+func ScopedRQName(hrqNamespace string, hrqName string) (string, error) {
+	if strings.Contains(hrqNamespace, "--") {
+		return "", fmt.Errorf("hrq namespace cannot contain '--': %s", hrqNamespace)
+	}
+	return api.ResourceQuotaSingletonName + "-" + hrqNamespace + "--" + hrqName, nil
 }
 
-func ScopedHRQNameFromHRQName(rqName string) (string, error) {
-	hrqName := strings.TrimPrefix(rqName, api.ResourceQuotaSingletonName+"-")
-	if hrqName == api.ResourceQuotaSingletonName {
-		return "", fmt.Errorf("invalid ScopedHRQ name: %s", hrqName)
+func ScopedHRQNameFromRQName(rqName string) (types.NamespacedName, error) {
+	if rqName == api.ResourceQuotaSingletonName {
+		return types.NamespacedName{}, fmt.Errorf("invalid RQ name for ScopedHRQ name: %s", rqName)
 	}
 
-	return hrqName, nil
+	parts := strings.SplitN(strings.TrimPrefix(rqName, api.ResourceQuotaSingletonName+"-"), "--", 2)
+	if len(parts) != 2 {
+		return types.NamespacedName{}, fmt.Errorf("invalid RQ name for ScopedHRQ: %s", rqName)
+	}
+
+	return types.NamespacedName{Namespace: parts[0], Name: parts[1]}, nil
 }

--- a/internal/hrq/utils/scopedhrq.go
+++ b/internal/hrq/utils/scopedhrq.go
@@ -74,7 +74,7 @@ func ScopedRQName(hrqNamespace string, hrqName string) (string, error) {
 
 	namespaceAndName := truncate(
 		fmt.Sprintf("%s-%s", hrqNamespace, hrqName),
-		validation.DNS1123SubdomainMaxLength-len(hashStr)-len(api.ResourceQuotaSingletonName)-2,
+		uint(validation.DNS1123SubdomainMaxLength-len(hashStr)-len(api.ResourceQuotaSingletonName)-2),
 	)
 
 	return fmt.Sprintf("%s-%s-%s", api.ResourceQuotaSingletonName, namespaceAndName, hashStr), nil
@@ -94,8 +94,8 @@ func SetLabelsAnnotationsForScopedRQ(rq *v1.ResourceQuota, hrqNamespace string, 
 	metadata.SetLabel(rq, hrqNameLabel, hrqName)
 }
 
-func truncate(s string, n int) string {
-	if len(s) <= n {
+func truncate(s string, n uint) string {
+	if uint(len(s)) <= n {
 		return s
 	}
 	return s[:n]

--- a/internal/hrq/utils/scopedhrq.go
+++ b/internal/hrq/utils/scopedhrq.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	HRQNameLabel          = "hnc.x-k8s.io/hrq-name"
-	HRQNamespaceLabel     = "hnc.x-k8s.io/hrq-namespace"
-	NewScopedRQAnnotation = "hnc.x-k8s.io/new-scoped-rq"
+	hrqNameLabel          = "hnc.x-k8s.io/hrq-name"
+	hrqNamespaceLabel     = "hnc.x-k8s.io/hrq-namespace"
+	newScopedRQAnnotation = "hnc.x-k8s.io/new-scoped-rq"
 )
 
 const (
@@ -48,7 +48,7 @@ func IsLegacyScopedRQ(rq *v1.ResourceQuota) bool {
 	if !IsHNCManagedRQ(rq) {
 		return false
 	}
-	if v, ok := metadata.GetAnnotation(rq, NewScopedRQAnnotation); ok && v == "true" {
+	if v, ok := metadata.GetAnnotation(rq, newScopedRQAnnotation); ok && v == "true" {
 		return false
 	}
 	return true
@@ -83,12 +83,18 @@ func ScopedRQName(hrqNamespace string, hrqName string) (string, error) {
 }
 
 func ScopedHRQNameFromRQ(rq *v1.ResourceQuota) (types.NamespacedName, error) {
-	namespace, nsOK := metadata.GetLabel(rq, HRQNamespaceLabel)
-	name, nameOK := metadata.GetLabel(rq, HRQNameLabel)
+	namespace, nsOK := metadata.GetLabel(rq, hrqNamespaceLabel)
+	name, nameOK := metadata.GetLabel(rq, hrqNameLabel)
 	if nsOK && nameOK {
 		return types.NamespacedName{Namespace: namespace, Name: name}, nil
 	}
 	return types.NamespacedName{}, fmt.Errorf("no matching HRQ found for RQ: %s", rq.Name)
+}
+
+func SetLabelsAnnotationsForScopedRQ(rq *v1.ResourceQuota, hrqNamespace string, hrqName string) {
+	metadata.SetLabel(rq, hrqNamespaceLabel, hrqNamespace)
+	metadata.SetLabel(rq, hrqNameLabel, hrqName)
+	metadata.SetAnnotation(rq, newScopedRQAnnotation, "true")
 }
 
 func truncate(s string, n int) string {

--- a/internal/hrq/utils/scopedhrq.go
+++ b/internal/hrq/utils/scopedhrq.go
@@ -13,9 +13,8 @@ import (
 )
 
 const (
-	hrqNameLabel          = "hnc.x-k8s.io/hrq-name"
-	hrqNamespaceLabel     = "hnc.x-k8s.io/hrq-namespace"
-	newScopedRQAnnotation = "hnc.x-k8s.io/new-scoped-rq"
+	hrqNameLabel      = "hnc.x-k8s.io/hrq-name"
+	hrqNamespaceLabel = "hnc.x-k8s.io/hrq-namespace"
 )
 
 const (
@@ -48,10 +47,9 @@ func IsLegacyScopedRQ(rq *v1.ResourceQuota) bool {
 	if !IsHNCManagedRQ(rq) {
 		return false
 	}
-	if v, ok := metadata.GetAnnotation(rq, newScopedRQAnnotation); ok && v == "true" {
-		return false
-	}
-	return true
+	_, nsLabelFound := metadata.GetLabel(rq, hrqNamespaceLabel)
+	_, nameLabelFound := metadata.GetLabel(rq, hrqNameLabel)
+	return !nsLabelFound || !nameLabelFound
 }
 
 // LegacyScopedRQName generates the legacy RQ name for backward compatibility
@@ -94,7 +92,6 @@ func ScopedHRQNameFromRQ(rq *v1.ResourceQuota) (types.NamespacedName, error) {
 func SetLabelsAnnotationsForScopedRQ(rq *v1.ResourceQuota, hrqNamespace string, hrqName string) {
 	metadata.SetLabel(rq, hrqNamespaceLabel, hrqNamespace)
 	metadata.SetLabel(rq, hrqNameLabel, hrqName)
-	metadata.SetAnnotation(rq, newScopedRQAnnotation, "true")
 }
 
 func truncate(s string, n int) string {

--- a/internal/hrq/utils/scopedhrq.go
+++ b/internal/hrq/utils/scopedhrq.go
@@ -8,6 +8,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 	"sigs.k8s.io/hierarchical-namespaces/internal/metadata"
 )
@@ -15,10 +16,6 @@ import (
 const (
 	hrqNameLabel      = "hnc.x-k8s.io/hrq-name"
 	hrqNamespaceLabel = "hnc.x-k8s.io/hrq-namespace"
-)
-
-const (
-	maxRQNameLength = 253
 )
 
 func IsSingletonRQ(rq *v1.ResourceQuota) bool {
@@ -75,7 +72,10 @@ func ScopedRQName(hrqNamespace string, hrqName string) (string, error) {
 	hash := md5.Sum([]byte(fmt.Sprintf("%s/%s", hrqNamespace, hrqName)))
 	hashStr := hex.EncodeToString(hash[:])
 
-	namespaceAndName := truncate(fmt.Sprintf("%s-%s", hrqNamespace, hrqName), maxRQNameLength-len(hashStr)-len(api.ResourceQuotaSingletonName)-2)
+	namespaceAndName := truncate(
+		fmt.Sprintf("%s-%s", hrqNamespace, hrqName),
+		validation.DNS1123SubdomainMaxLength-len(hashStr)-len(api.ResourceQuotaSingletonName)-2,
+	)
 
 	return fmt.Sprintf("%s-%s-%s", api.ResourceQuotaSingletonName, namespaceAndName, hashStr), nil
 }

--- a/internal/hrq/utils/scopedhrq_test.go
+++ b/internal/hrq/utils/scopedhrq_test.go
@@ -1,0 +1,37 @@
+package utils
+
+import "testing"
+
+func TestScopedRQName(t *testing.T) {
+	tests := []struct {
+		name         string
+		hrqNamespace string
+		hrqName      string
+		want         string
+	}{
+		{
+			name:         "short",
+			hrqNamespace: "default",
+			hrqName:      "test",
+			want:         "hrq.hnc.x-k8s.io-default-test-1b5cb9615ea99c0edaf5b1f157ce3997",
+		},
+		{
+			name:         "too_long",
+			hrqNamespace: "default",
+			hrqName:      "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
+			want:         "hrq.hnc.x-k8s.io-default-123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345-dc2d54f49ea75bc9da92c7272bc626d7", // 253 chars
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ScopedRQName(test.hrqNamespace, test.hrqName)
+			if err != nil {
+				t.Errorf("ScopedRQName(%s, %s) = %v", test.hrqNamespace, test.hrqName, err)
+			}
+			if got != test.want {
+				t.Errorf("ScopedRQName(%s, %s) = %s, want %s", test.hrqNamespace, test.hrqName, got, test.want)
+			}
+		})
+	}
+}

--- a/test/e2e/pfn_hrq_test.go
+++ b/test/e2e/pfn_hrq_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/hrq/utils"
 	"sigs.k8s.io/yaml"
 
 	"github.com/google/uuid"
@@ -114,6 +115,24 @@ var _ = Describe("Scoped Hierarchical Resource Quota", Label("pfnet"), func() {
 
 		FieldShouldContain("hrq", parentNs, hrq.Name, ".status.used", "pods:1")
 	})
+
+	It("should remove the legacy RQ", func() {
+		hrqName := "legacy-hrq"
+
+		// Legacy RQ remains before the new RQ is created
+		legacyRQ := mustCreateLegacyRQ(parentNs, hrqName, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")})
+		RunShouldContain(legacyRQ.Name, propagationTime, "kubectl get resourcequota -n", parentNs)
+
+		// Create the HRQ
+		setScopedHRQ(hrqName, parentNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")}, &scopeSelector)
+
+		// Confirm the new RQ is created
+		newRQName := api.ResourceQuotaSingletonName + "-" + parentNs + "-" + hrqName + "-" + md5Hash(parentNs+"/"+hrqName)
+		RunShouldContain(newRQName, propagationTime, "kubectl get resourcequota -n", parentNs, newRQName)
+
+		// Legacy RQ is removed
+		RunShouldNotContain(legacyRQ.Name, propagationTime, "kubectl get resourcequota -n", parentNs)
+	})
 })
 
 func mustCreatePod(prefix, nsnm string) (corev1.Pod, error) {
@@ -215,6 +234,32 @@ func createSubNS(parent, prefix string) string {
 	nsName := prefix + uuid.New().String()
 	MustRun("kubectl hns create", nsName, "-n", parent)
 	return nsName
+}
+
+func mustCreateLegacyRQ(ns, hrqName string, resourceList corev1.ResourceList) corev1.ResourceQuota {
+	hrq := corev1.ResourceQuota{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ResourceQuota",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.LegacyScopedRQName(hrqName),
+			Namespace: ns,
+			Labels: map[string]string{
+				api.HRQLabelCleanup: "true",
+			},
+		},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: resourceList,
+		},
+	}
+	manifest, err := yaml.Marshal(hrq)
+	Expect(err).NotTo(HaveOccurred())
+
+	MustApplyYAML(string(manifest))
+	RunShouldContain(hrq.Name, propagationTime, "kubectl get resourcequota -n", ns, hrq.Name)
+
+	return hrq
 }
 
 func genPriorityScopeSelector() (corev1.ScopeSelector, string, func()) {

--- a/test/e2e/pfn_hrq_test.go
+++ b/test/e2e/pfn_hrq_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -61,8 +63,8 @@ var _ = Describe("Scoped Hierarchical Resource Quota", Label("pfnet"), func() {
 		hrqA := setScopedHRQ("same-name-hrq", parentNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("3")}, &scopeSelector)
 		hrqB := setScopedHRQ("same-name-hrq", childNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("2")}, &scopeSelector)
 
-		rqAName := api.ResourceQuotaSingletonName + "-" + parentNs + "--" + hrqA.Name
-		rqBName := api.ResourceQuotaSingletonName + "-" + childNs + "--" + hrqB.Name
+		rqAName := api.ResourceQuotaSingletonName + "-" + parentNs + "-" + hrqA.Name + "-" + md5Hash(parentNs+"/"+hrqA.Name)
+		rqBName := api.ResourceQuotaSingletonName + "-" + childNs + "-" + hrqB.Name + "-" + md5Hash(childNs+"/"+hrqB.Name)
 
 		FieldShouldContain("resourcequota", parentNs, rqAName, ".spec.hard", "pods:3")
 		FieldShouldContain("resourcequota", childNs, rqAName, ".spec.hard", "pods:3")
@@ -237,4 +239,9 @@ func genPriorityScopeSelector() (corev1.ScopeSelector, string, func()) {
 
 func selectorStr(priorityName string) string {
 	return "map[matchExpressions:[map[operator:In scopeName:PriorityClass values:[" + priorityName + "]]]]"
+}
+
+func md5Hash(s string) string {
+	hash := md5.Sum([]byte(s))
+	return hex.EncodeToString(hash[:])
 }

--- a/test/e2e/pfn_hrq_test.go
+++ b/test/e2e/pfn_hrq_test.go
@@ -58,23 +58,25 @@ var _ = Describe("Scoped Hierarchical Resource Quota", Label("pfnet"), func() {
 	})
 
 	It("should create RQs with correct limits in the descendants (including itself) for Scoped HRQs", func() {
-		hrqA := setScopedHRQ("a-hrq", parentNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("3")}, &scopeSelector)
-		hrqB := setScopedHRQ("b-hrq", childNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("2")}, &scopeSelector)
+		hrqA := setScopedHRQ("same-name-hrq", parentNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("3")}, &scopeSelector)
+		hrqB := setScopedHRQ("same-name-hrq", childNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("2")}, &scopeSelector)
 
-		rqAName := api.ResourceQuotaSingletonName + "-" + hrqA.Name
-		rqBName := api.ResourceQuotaSingletonName + "-" + hrqB.Name
+		rqAName := api.ResourceQuotaSingletonName + "-" + parentNs + "--" + hrqA.Name
+		rqBName := api.ResourceQuotaSingletonName + "-" + childNs + "--" + hrqB.Name
 
 		FieldShouldContain("resourcequota", parentNs, rqAName, ".spec.hard", "pods:3")
+		FieldShouldContain("resourcequota", childNs, rqAName, ".spec.hard", "pods:3")
 		FieldShouldContain("resourcequota", childNs, rqBName, ".spec.hard", "pods:2")
 
 		expect := selectorStr(priorityName)
 		FieldShouldContain("resourcequota", parentNs, rqAName, ".spec.scopeSelector", expect)
+		FieldShouldContain("resourcequota", childNs, rqAName, ".spec.scopeSelector", expect)
 		FieldShouldContain("resourcequota", childNs, rqBName, ".spec.scopeSelector", expect)
 	})
 
 	It("should remove obsolete (empty) RQ if there's no longer a Scoped HRQ in the ancestor", func() {
 		hrq := setScopedHRQ("a-hrq", parentNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("3")}, &scopeSelector)
-		rqName := api.ResourceQuotaSingletonName + "-" + hrq.Name
+		rqName := api.ResourceQuotaSingletonName + "-" + parentNs + "--" + hrq.Name
 
 		MustRun("kubectl delete hrq -n", parentNs, hrq.Name)
 

--- a/test/e2e/pfn_hrq_test.go
+++ b/test/e2e/pfn_hrq_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Scoped Hierarchical Resource Quota", Label("pfnet"), func() {
 
 	It("should remove obsolete (empty) RQ if there's no longer a Scoped HRQ in the ancestor", func() {
 		hrq := setScopedHRQ("a-hrq", parentNs, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("3")}, &scopeSelector)
-		rqName := api.ResourceQuotaSingletonName + "-" + parentNs + "--" + hrq.Name
+		rqName := api.ResourceQuotaSingletonName + "-" + parentNs + "-" + hrq.Name + "-" + md5Hash(parentNs+"/"+hrq.Name)
 
 		MustRun("kubectl delete hrq -n", parentNs, hrq.Name)
 


### PR DESCRIPTION
Previously, there was an issue where the names of scoped RQs created from scoped HRQs could conflict. This PR fixes that problem.

# Problem

In the previous implementation, the name of a scoped RQ was just a prefixed version of the scoped HRQ name. As a result, if a parent namespace and a child namespace had scoped HRQs with the same name, it would try to create RQs with the same name in the child namespace and fail.

# Solution

This PR changes the RQ naming to include the namespace name and an MD5 hash of `hrqNamespace/hrqName`. However, since this can make the name exceed the length limit, the name is truncated appropriately when it's too long.