### PR TITLE
feat: Expose HRQ limit and usage on metrics endpoint.

### DIFF
--- a/internal/hrq/metrics.go
+++ b/internal/hrq/metrics.go
@@ -1,0 +1,81 @@
+package hrq
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+)
+
+func RegisterMetrics(mgr ctrl.Manager) error {
+	if err := metrics.Registry.Register(&hrqCollector{
+		client:  mgr.GetClient(),
+		logger:  mgr.GetLogger().WithValues("collector", "hrqCollector"),
+		timeout: time.Second * 10,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+type hrqCollector struct {
+	timeout time.Duration
+	client  client.Client
+	logger  logr.Logger
+}
+
+func (c *hrqCollector) desc() *prometheus.Desc {
+	return prometheus.NewDesc(
+		"hnc_hierarchicalresourcequota",
+		"HRQ hard/used like kube_resourcequota",
+		[]string{"namespace", "hrq", "resource", "type"},
+		nil,
+	)
+}
+
+func (c *hrqCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc()
+}
+
+func (c *hrqCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	var hrqs api.HierarchicalResourceQuotaList
+	if err := c.client.List(ctx, &hrqs); err != nil {
+		c.logger.Error(err, "Failed to list HRQs during metrics collection")
+		return
+	}
+
+	for _, hrq := range hrqs.Items {
+		for typeLabel, resList := range map[string]corev1.ResourceList{
+			"hard": hrq.Status.Hard,
+			"used": hrq.Status.Used,
+		} {
+			for res, qty := range resList {
+				v, ok := qty.AsInt64()
+				if !ok {
+					c.logger.Info("Failed to get the quantity value", "namespace", hrq.Namespace, "hrq", hrq.Name, "resource", res)
+					continue
+				}
+
+				ch <- prometheus.MustNewConstMetric(
+					c.desc(),
+					prometheus.GaugeValue,
+					float64(v),
+					hrq.Namespace,
+					hrq.Name,
+					string(res),
+					typeLabel,
+				)
+			}
+		}
+	}
+}

--- a/internal/setup/reconcilers.go
+++ b/internal/setup/reconcilers.go
@@ -109,6 +109,10 @@ func CreateReconcilers(mgr ctrl.Manager, f *forest.Forest, opts Options) error {
 		if opts.HRQSyncInterval != 0 {
 			go watchHRQDrift(f, opts.HRQSyncInterval, hrqr)
 		}
+
+		if err := hrq.RegisterMetrics(mgr); err != nil {
+			return fmt.Errorf("cannot register HRQ metrics: %w", err)
+		}
 	}
 
 	if err := ar.SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
This exposes HRQ limit and usage on the metrics endpoint.

The metric labels align with [kube_resourcequota](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/policy/resourcequota-metrics.md) metric of kube-state-metrics.

```
$ curl --silent localhost:8080/metrics | grep hnc_hierarchicalresourcequota
# HELP hnc_hierarchicalresourcequota HRQ hard/used like kube_resourcequota
# TYPE hnc_hierarchicalresourcequota gauge
hnc_hierarchicalresourcequota{hrq="test-a",namespace="test-parent",resource="cpu",type="hard"} 20
hnc_hierarchicalresourcequota{hrq="test-a",namespace="test-parent",resource="cpu",type="used"} 0
hnc_hierarchicalresourcequota{hrq="test-a",namespace="test-parent",resource="memory",type="hard"} 4.294967296e+10
hnc_hierarchicalresourcequota{hrq="test-a",namespace="test-parent",resource="memory",type="used"} 0
```

